### PR TITLE
Update nin.json configuration, add authors

### DIFF
--- a/nin.json
+++ b/nin.json
@@ -1,5 +1,6 @@
 {
-    "name": "Dr. Crankwork Steamfist",
+    "title": "Crankwork Steamfist",
+    "authors": ["iverjo",  "sigveseb",  "cristea",  "run", "finninde",  "capitalism",  "A Jacobsen", "profit", "stiaje", "alf"],
     "music": {
         "bpm": 130,
         "subdivision": 6


### PR DESCRIPTION
This adds more metadata for use in the nin metadata generator!
The previously-unused name field is renamed to title for consistency.

Once https://github.com/ninjadev/nin/pull/248 is merged, this metadata will show up in compiled versions.
